### PR TITLE
remove Vitest setup file

### DIFF
--- a/setupVitest.js
+++ b/setupVitest.js
@@ -1,7 +1,0 @@
-import createFetchMock from 'vitest-fetch-mock'
-import { vi } from 'vitest'
-
-const fetchMocker = createFetchMock(vi)
-
-// sets globalThis.fetch and globalThis.fetchMock to our mocked version
-fetchMocker.enableMocks()


### PR DESCRIPTION
This file appears to be unused.

The file was not being hit during test coverage. 
Removing it does NOT appear to affect tests, but does improve coverage.
